### PR TITLE
Prevent Steam's controller mappings from being overridden by defaults

### DIFF
--- a/Chowdren/base/desktop/platform.cpp
+++ b/Chowdren/base/desktop/platform.cpp
@@ -1593,6 +1593,15 @@ void init_joystick()
 {
     SDL_GameControllerAddMappingsFromFile("gamecontrollerdb.txt");
 
+    // Reload mappings passed through the environment (by Steam, etc)
+    // so that the ones in gamecontrollerdb.txt don't override them:
+    const char *hint = SDL_GetHint(SDL_HINT_GAMECONTROLLERCONFIG);
+    if (hint && hint[0]) {
+      const size_t hintlen = SDL_strlen(hint);
+      SDL_RWops *hint_rwops = SDL_RWFromConstMem(hint, hintlen+1);
+      SDL_GameControllerAddMappingsFromRW(hint_rwops, 1);
+    };
+
     rumble_effect.type = SDL_HAPTIC_LEFTRIGHT;
     rumble_effect.leftright.length = 0;
 

--- a/Chowdren/base/desktop/platform.cpp
+++ b/Chowdren/base/desktop/platform.cpp
@@ -1597,10 +1597,10 @@ void init_joystick()
     // so that the ones in gamecontrollerdb.txt don't override them:
     const char *hint = SDL_GetHint(SDL_HINT_GAMECONTROLLERCONFIG);
     if (hint && hint[0]) {
-      const size_t hintlen = SDL_strlen(hint);
-      SDL_RWops *hint_rwops = SDL_RWFromConstMem(hint, hintlen+1);
-      SDL_GameControllerAddMappingsFromRW(hint_rwops, 1);
-    };
+        const size_t hintlen = SDL_strlen(hint);
+        SDL_RWops *hint_rwops = SDL_RWFromConstMem(hint, hintlen+1);
+        SDL_GameControllerAddMappingsFromRW(hint_rwops, 1);
+    }
 
     rumble_effect.type = SDL_HAPTIC_LEFTRIGHT;
     rumble_effect.leftright.length = 0;


### PR DESCRIPTION
Steam passes controller mappings through an environment variable; those mappings are automatically loaded during SDL_Init (provided the relevant subsystems are enabled.)
This allows users to set their own custom mapping for any arbitrary controller in Steam's Big Picture mode.

Currently, if a mapping for a controller already exists in gamecontrollerdb.txt, the mapping in the file will always be given precedence, since it's loaded after SDL_Init.

To reverse this situation and give priority to Steam's mappings, we can manually load the mappings from the environment variable a second time, after the ones in gamecontrollerdb.txt have been loaded.

If you believe that there's some situation where the user would want to override Steam's mappings with a file, you can simply add a second file (e.g. gamecontrollerdb-override.txt) and load it last.

Note: I've made reference to Steam because it's the most common scenario, but this isn't Steam-specific at all.